### PR TITLE
Add linking policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
 # tech256 Code of Conduct
 
-All participants in the tech256 chat are expected to follow the code of conduct. Administrators will enforce this code.
+All participants in the tech256 chat are expected to follow the code of
+conduct. Administrators will enforce this code.
 
 # The Quick Version
 
-tech256 is dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any chat topic. Participants violating these rules will be expelled from the group at the sole discretion of the group administrators.
+tech256 is dedicated to providing a harassment-free experience for everyone,
+regardless of gender, sexual orientation, disability, physical appearance, body
+size, race, or religion. We do not tolerate harassment of participants in any
+form. Sexual language and imagery is not appropriate for any chat topic.
+Participants violating these rules will be expelled from the group at the sole
+discretion of the group administrators.
 
 # The Less Quick Version
 
-Harassment includes offensive comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images, deliberate intimidation, stalking, sustained disruption of discussions or other events, and unwelcome sexual attention.
+Harassment includes offensive comments related to gender, sexual orientation,
+disability, physical appearance, body size, race, religion, sexual images,
+deliberate intimidation, stalking, sustained disruption of discussions or other
+events, and unwelcome sexual attention.
 
-Participants asked to stop any harassing behavior are expected to comply immediately.
+Participants asked to stop any harassing behavior are expected to comply
+immediately.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please notify an administrator immediately, or email <atldevs@forty9ten.com>.
+If you are being harassed, notice that someone else is being harassed, or have
+any other concerns, please notify an administrator immediately, or email
+<atldevs@forty9ten>.
 
 [This code of conduct is adapted from [Conference Code of Conduct](http://confcodeofconduct.com) under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US), additional content adapted from the [Gopher Academy Slack Code of Conduct](https://docs.google.com/document/d/1YO_xIZPhD1OsquKdCuAq-fFECs8b37wfhVRfnx3DjzM/edit)]
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# tech404 Code of Conduct
+# tech256 Code of Conduct
 
-All participants in the tech404 chat are expected to follow the code of conduct. Administrators will enforce this code.
+All participants in the tech256 chat are expected to follow the code of conduct. Administrators will enforce this code.
 
 # The Quick Version
 
-tech404 is dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any chat topic. Participants violating these rules will be expelled from the group at the sole discretion of the group administrators.
+tech256 is dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any chat topic. Participants violating these rules will be expelled from the group at the sole discretion of the group administrators.
 
 # The Less Quick Version
 
@@ -20,15 +20,7 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 If you have any issues or need help, please feel free to reach out to anyone on this list:
 
-* Aaron Feng (<aaron@forty9ten.com>)
-* Andy Lindeman
-* J Cornelius
-* John Dyer
-* Kylie Stradley (<ky@kyfast.net>)
-* Michael Langford
-* Pamela O. Vickers (<pwnela@gmail.com>)
-* Patrick Van Stee
-* Randall McPherson
+* [Jay Hayes](github.com/iamvery)
 
 ## Role of Admins
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ immediately.
 Group notifications (such as `@channel` and `@here`) may only be used by admins and channel "owners".
 An "owner" is an individual responsible in some way for the organization of the channel.
 For e.g. @jackbauer might @channel #ctu of an attempt on @davidpalmer's life.
-Enforcement of this is at the pure disgression of the admins.
+Enforcement of this is at the pure discretion of the admins.
 
 If you are being harassed, notice that someone else is being harassed, have a problem with notifications, or have
 any other concerns, please notify an administrator immediately, or email

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ themselves.
 
 tech256 is dedicated to providing a harassment-free experience for everyone,
 regardless of gender, sexual orientation, disability, physical appearance, body
-size, race, or religion. We do not tolerate harassment of participants in any
+size, race, religion, or political preference. We do not tolerate harassment of participants in any
 form. Sexual language and imagery is not appropriate for any chat topic.
 Participants violating these rules will be expelled from the group at the sole
 discretion of the group administrators.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Please reach out to one of the moderators if you believe your link was misinterp
 
 If you have any issues or need help, please feel free to reach out to anyone on this list:
 
-* [Jay Hayes](https://twitter.com/iamvery)
-* [Michael Carroll](https://twitter.com/carromj)
-* [Britany Meadows](https://twitter.com/letbritcode)
+* [Jay Hayes](https://twitter.com/iamvery) (`@jay`)
+* [Michael Carroll](https://twitter.com/carromj) (`@mjcarrol`)
+* [Britany Meadows](https://twitter.com/letbritcode) (`@britany`)
 
 ## Role of Admins
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ immediately.
 
 If you are being harassed, notice that someone else is being harassed, or have
 any other concerns, please notify an administrator immediately, or email
-<jay@iamvery.com>.
+<report@tech256.com>.
 
 [This code of conduct is adapted from [Conference Code of Conduct](http://confcodeofconduct.com) under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US), additional content adapted from the [Gopher Academy Slack Code of Conduct](https://docs.google.com/document/d/1YO_xIZPhD1OsquKdCuAq-fFECs8b37wfhVRfnx3DjzM/edit)]
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ events, and unwelcome sexual attention.
 Participants asked to stop any harassing behavior are expected to comply
 immediately.
 
-If you are being harassed, notice that someone else is being harassed, or have
+Group notifications (such as `@channel` and `@here`) may only be used by admins and channel "owners".
+An "owner" is an individual responsible in some way for the organization of the channel.
+For e.g. @jackbower might @channel #ctu of an attempt on @davidpalmer's life.
+Enforcement of this is at the pure disgression of the admins.
+
+If you are being harassed, notice that someone else is being harassed, have a problem with notifications, or have
 any other concerns, please notify an administrator immediately, or email
 <report@tech256.com>.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ any other concerns, please notify an administrator immediately, or email
 If you have any issues or need help, please feel free to reach out to anyone on this list:
 
 * [Jay Hayes](https://twitter.com/iamvery)
-* [Bryan Powel](https://twitter.com/bryanp)
 * [Michael Carroll](https://twitter.com/carromj)
 * [Britany Meadows](https://twitter.com/letbritcode)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If you have any issues or need help, please feel free to reach out to anyone on 
 * [Jay Hayes](https://twitter.com/iamvery)
 * [Bryan Powel](https://twitter.com/bryanp)
 * [Michael Carroll](https://twitter.com/carromj)
+* [Britany Meadows](https://twitter.com/letbritcode)
 
 ## Role of Admins
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 If you have any issues or need help, please feel free to reach out to anyone on this list:
 
-* [Jay Hayes](github.com/iamvery)
+* [Jay Hayes](https://twitter.com/iamvery)
+* [Bryan Powel](https://twitter.com/bryanp)
 
 ## Role of Admins
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ immediately.
 
 If you are being harassed, notice that someone else is being harassed, or have
 any other concerns, please notify an administrator immediately, or email
-<atldevs@forty9ten>.
+<jay@iamvery.com>.
 
 [This code of conduct is adapted from [Conference Code of Conduct](http://confcodeofconduct.com) under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US), additional content adapted from the [Gopher Academy Slack Code of Conduct](https://docs.google.com/document/d/1YO_xIZPhD1OsquKdCuAq-fFECs8b37wfhVRfnx3DjzM/edit)]
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you have any issues or need help, please feel free to reach out to anyone on 
 
 * [Jay Hayes](https://twitter.com/iamvery)
 * [Bryan Powel](https://twitter.com/bryanp)
+* [Michael Carroll](https://twitter.com/carromj)
 
 ## Role of Admins
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 All participants in the tech256 chat are expected to follow the code of
 conduct. Administrators will enforce this code.
 
+User accounts shall not be shared and shall represent individuals as
+themselves.
+
 # The Quick Version
 
 tech256 is dedicated to providing a harassment-free experience for everyone,

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ If you are being harassed, notice that someone else is being harassed, have a pr
 any other concerns, please notify an administrator immediately, or email
 <report@tech256.com>.
 
+Spam or malicious links are prohibited and will be deleted.
+Please reach out to one of the moderators if you believe your link was misinterpreted as spam or malicious.
+
 [This code of conduct is adapted from [Conference Code of Conduct](http://confcodeofconduct.com) under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US), additional content adapted from the [Gopher Academy Slack Code of Conduct](https://docs.google.com/document/d/1YO_xIZPhD1OsquKdCuAq-fFECs8b37wfhVRfnx3DjzM/edit)]
 
 # Admins

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ immediately.
 
 Group notifications (such as `@channel` and `@here`) may only be used by admins and channel "owners".
 An "owner" is an individual responsible in some way for the organization of the channel.
-For e.g. @jackbower might @channel #ctu of an attempt on @davidpalmer's life.
+For e.g. @jackbauer might @channel #ctu of an attempt on @davidpalmer's life.
 Enforcement of this is at the pure disgression of the admins.
 
 If you are being harassed, notice that someone else is being harassed, have a problem with notifications, or have


### PR DESCRIPTION
# Problem

We have seen an increase in people joining and immediately using the community to promote something without any intention of contributing or sticking around. Beyond self-promotion, links may also be malicious.

# Solution

To protect people and relieve us of noise, we are adding a policy to the code of conduct that states links will be deleted by moderators discretion.

Thank you to @blmeadows for her help with the copy and proposing a solution.